### PR TITLE
Gammam note on psd

### DIFF
--- a/_docs/Capitolo6.rst
+++ b/_docs/Capitolo6.rst
@@ -175,8 +175,6 @@ seguente significato:
 |                                  |         |         |         |         | nel flusso.                                      |
 +----------------------------------+---------+---------+---------+---------+--------------------------------------------------+
 | identificativoUnivocoRiscossione | 2       | an      | 1..1    | 1..35   | Riferimento univoco dell’operazione              |
-|                                  |         |         |         |         | assegnato al pagamento dal Prestatore            |
-|                                  |         |         |         |         | dei servizi di Pagamento                         |
 +----------------------------------+---------+---------+---------+---------+--------------------------------------------------+
 | indiceDatiSingoloPagamento       | 2       | n       | 0..1    | 1       | Indice dell’occorrenza del pagamento             |
 |                                  |         |         |         |         | all’interno della struttura                      |

--- a/_docs/Capitolo6.rst
+++ b/_docs/Capitolo6.rst
@@ -204,7 +204,7 @@ seguente significato:
 |                                  |         |         |         |         |                                                  |
 |                                  |         |         |         |         |                                                  |
 |                                  |         |         |         |         | - **9** = Pagamento eseguito                     |
-|                                  |         |         |         |         |   in assenza di RPT                              |
+|                                  |         |         |         |         |   in presenza di presenza di anomalie            |
 +----------------------------------+---------+---------+---------+---------+--------------------------------------------------+
 | dataEsitoSingoloPagamento        | 2       | an      | 1..1    | 10      | Indica la data in cui è stato                    |
 |                                  |         |         |         |         | disposto o revocato il pagamento,                |

--- a/_docs/Capitolo6.rst
+++ b/_docs/Capitolo6.rst
@@ -85,8 +85,7 @@ seguente significato:
 |                                  |         |         |         |         |                                                  |
 |                                  |         |         |         |         | **[YYYY]-[MM]-[DD]T[hh]:[mm]:[ss]**              |
 +----------------------------------+---------+---------+---------+---------+--------------------------------------------------+
-| identificativoUnivocoRegolamento | 1       | an      | 1..1    | 1..35   | Riferimento assegnato dal prestatore di          |
-|                                  |         |         |         |         | servizi di pagamento all’operazione di           |
+| identificativoUnivocoRegolamento | 1       | an      | 1..1    | 1..35   | Riferimento dell’operazione di           |
 |                                  |         |         |         |         | trasferimento fondi con la quale viene           |
 |                                  |         |         |         |         | regolato contabilmente il riversamento           |
 |                                  |         |         |         |         | delle somme incassate ovvero l’accumulo          |
@@ -251,16 +250,9 @@ indicato della RT rendicontata (cfr. Allegato B alle Linee guida *“Specifiche 
 
 **identificativoUnivocoRegolamento:** ulteriore dato ‘non ambiguo’
 utilizzato per abbinare il flusso di rendicontazione con l’accredito
-ricevuto. Può contenere, in alternativa, uno dei seguenti dati
-presenti nel SCT di riversamento (cfr. *SEPA Credit Transfert Scheme
-Rulebook*):
+ricevuto. Contiene il *Transaction Reference Number* (TRN, attributo AT-43 Originator Bank’s Reference) dell'SCT 
+di riversamento (cfr. *SEPA Credit Transfert Scheme Rulebook*):
 
-- a) *Transaction Reference Number* (TRN, attributo AT-43 Originator
-     Bank’s Reference), qualora il PSP, al momento della generazione
-     del flusso di rendicontazione, disponga di tale dato;
-
-- b) *EndToEndId* (attributo AT-41 Originator’s Reference), in caso
-     contrario.
 
 **identificativoUnivocoRiscossione:** rappresenta l’identificativo
 con il quale il prestatore di servizi di pagamento individua la


### PR DESCRIPTION
Questa PR propone le seguenti modifiche sulla descrizione dei campi di un FdR :  

- *identificativoUnivocoRegolamento* :  richiedendo un solo SCT cumulativo credo sia necessario fare chiarezza di come associare l'FdR all'SCT di competenza. Il PSP dovrebbe prima eseguire il bonifico, acquisire il TRN,  e poi inviare il flusso.
- *identificativoUnivocoRiscossione* : eliminiamo la dicitura che indica l'assegnazione di tale informazione al solo PSP. lo IUR identifica univocamente il pagamento avvenuto sul nodo. 
- *codiceEsitoSingoloPagamento=9*, lo classifichiamo come qualsiasi pagamento avvenuto sul nodo in presenza di anomalie , tralasciamo il riferimento esplicito all'RPT. 